### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: Java CI/CD Pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/vinaysinghhata5-oss/devops-cicd-project/security/code-scanning/1](https://github.com/vinaysinghhata5-oss/devops-cicd-project/security/code-scanning/1)

The best way to fix this problem is to add a `permissions` key to the workflow. This can be at the root level, which will apply its settings to all jobs in the workflow unless individually overridden. For this workflow, the minimum required permission is `contents: read`, as it only checks out code, builds, tests, and scans for vulnerabilities—none of which require write access to the repository or other resources. The edit should be made near the top of `.github/workflows/docker-image.yml`, right after the `name:` and before the `on:` key, or (alternatively) just after the trigger block (`on:`) and before `jobs:`. It is not necessary to change any of the job steps, imports, or other regions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
